### PR TITLE
fix(sec): upgrade golang.org/x/image to 0.5.0

### DIFF
--- a/server/cmd/go.mod
+++ b/server/cmd/go.mod
@@ -5,5 +5,5 @@ go 1.12
 require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	gocv.io/x/gocv v0.20.0
-	golang.org/x/image v0.0.0-20190523035834-f03afa92d3ff // indirect
+	golang.org/x/image v0.5.0 // indirect
 )

--- a/server/cmd/go.sum
+++ b/server/cmd/go.sum
@@ -4,4 +4,6 @@ gocv.io/x/gocv v0.20.0 h1:2q75zQ8Zel2tB69G6qrmf/E7EdvaCs90qvkHzdSBOAg=
 gocv.io/x/gocv v0.20.0/go.mod h1:vZETJRwLnl11muQ6iL3q4ju+0oJRrdmYdv5xJTH7WYA=
 golang.org/x/image v0.0.0-20190523035834-f03afa92d3ff h1:+2zgJKVDVAz/BWSsuniCmU1kLCjL88Z8/kv39xCI9NQ=
 golang.org/x/image v0.0.0-20190523035834-f03afa92d3ff/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
+golang.org/x/image v0.5.0 h1:5JMiNunQeQw++mMOz48/ISeNu3Iweh/JaZU8ZLqHRrI=
+golang.org/x/image v0.5.0/go.mod h1:FVC7BI/5Ym8R25iw5OLsgshdUBbT1h5jZTpA+mvAdZ4=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in golang.org/x/image v0.0.0-20190523035834-f03afa92d3ff
- [CVE-2022-41727](https://www.oscs1024.com/hd/CVE-2022-41727)


### What did I do？
Upgrade golang.org/x/image from v0.0.0-20190523035834-f03afa92d3ff to 0.5.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS